### PR TITLE
Update README with examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,66 @@
 ![mapular logo](http://alliants.github.io/mapular/images/mapular-logo.png)
 # Mapular
+
 [![Build Status](https://travis-ci.org/Alliants/mapular.svg?branch=master)](https://travis-ci.org/Alliants/mapular)
 
-A simple Angular module for generating device specific map urls for responsive sites.
+A simple Angular module for generating device-specific map urls. Allows responsive sites to open the device-native maps app from your Angular app.  Mapular currently supports generating map urls from coordinates.  Desktop browsers will be sent to the Google Maps website.
 
-Currently supports generating map urls from coordinates.
+## Demo
+A demo of the module can be found at [alliants.github.com/mapular](https://alliants.github.com/mapular)
 
-### Example
+## Example
 ```
-Mapular.url( { latitude: 50.839766, longitude: -1.148695} )
+<a ng-href="{{ mapsUrl({ latitude: property.latitude, longitude: property.longitude }) }}">My Location</a>
 ```
-Would return `'//maps.apple.com/?ll=50.839766,-1.148695'` on an iOS device and `//maps.google.com/maps?q=50.839766,-1.148695'` on an Android 4.x device.
+Would render as `<a href="//maps.apple.com/?ll=50.839766,-1.148695">My Location</a>` on an iOS device, which would open in the Apple Maps app when clicked.
 
-The default scheme for unknown devices is `//maps.google.com/maps?q=x,y'`
+### Default behaviour
+
+| Platform    | Version | Map provider         |
+|:--------    |:-------:|:------------         |
+| iOS       | any     | Apple Maps           |
+| Android     | >= 5.0  | RFC5870 `geo:`       |
+| Android         | < 5.0   | Google Maps          |
+| Windows Phone   | any     | Bing Maps `bingmaps:`|
+| Desktop     | all     | Google Maps          |
+
+The default scheme for unknown devices is `//maps.google.com/maps?q=x,y`
+
+## Installation
+### Bower component
+Mapular is available via [bower](http://bower.io/), simply
+
+```bower install mapular --save```
+
+Or explicity add Mapular to your `bower.json` dependencies:
+
+```json
+"dependencies": {
+  "mapular": "1.x.x",
+}
+```
+
+### Include the component
+Add Mapular to your page template, somewhere after Angular
+
+```html
+<script src="/bower_components/angular/angular.js"></script>
+<script src="/bower_components/mapular/src/mapular.js"></script>
+```
 
 ### Whitelisting URL schemes
-You will need to add the `geo` and `bingmaps` url scheme to your href whitelist:
+You will need to add the `geo` and `bingmaps` url scheme to your href whitelist to prevent Angular prefixing the url with `unsafe:`
 
 ```javascript
-.config(['$httpProvider', '$locationProvider', '$compileProvider',
-  function ($httpProvider, $locationProvider, $compileProvider) {
+.config(['$compileProvider',
+  function ($compileProvider) {
     $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|ftp|mailto|geo|tel|bingmaps):/);
+    // Angular before v1.2 uses $compileProvider.urlSanitizationWhitelist(...)
   }]);
 ```
 
-### Demo
-A demo of the module can be found at [alliants.github.com/mapular](https://alliants.github.com/mapular)
+## Contributing and Issues
+The list of supported user agents is not exhastive but does provide a sensible baseline.  Any contributions to expand the list of supported user agents in the test suite or to cover edge cases are welcome.
 
-
-### Licence
+## Licence
 Mapular is available under the MIT license.


### PR DESCRIPTION
In response to issue #1 

I think the better UX behaviour for desktop users is to be sent to Google Maps (web) rather than open the Apple Maps desktop App.  I have update the readme to make this behaviour more explicit.

I have also update the href whitlisting example to remove unnecessary dependencies.
